### PR TITLE
Fix NullReferenceException in AnimationRuntime

### DIFF
--- a/GumCommon/Runtime/AnimationRuntime.cs
+++ b/GumCommon/Runtime/AnimationRuntime.cs
@@ -145,7 +145,10 @@ public class AnimationRuntime
             }
 
             // The custom state can be null if the animation window references states which don't exist:
-            stateToSet = keyframeAfter.CachedCumulativeState.Clone();
+            if(keyframeAfter.CachedCumulativeState != null)
+            {
+                stateToSet = keyframeAfter.CachedCumulativeState.Clone();
+            }
         }
         else if (keyframeBefore != null && keyframeAfter == null)
         {
@@ -156,8 +159,10 @@ public class AnimationRuntime
                     RefreshCumulativeStates(element);
                 }
             }
-
-            stateToSet = keyframeBefore.CachedCumulativeState.Clone();
+            if(keyframeBefore.CachedCumulativeState != null)
+            {
+                stateToSet = keyframeBefore.CachedCumulativeState.Clone();
+            }
         }
         else if (keyframeBefore != null && keyframeAfter != null)
         {


### PR DESCRIPTION
## Summary
- guard against `CachedCumulativeState` being null when applying animations

## Testing
- `dotnet test GumUnitTests/GumUnitTests.csproj --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847e067aa348324bf1afdd5a595021d